### PR TITLE
Added prop forwarding

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,10 +31,10 @@ export class PasswordInput extends React.Component<PasswordInputProps> {
     };
 
     render() {
-        const { settings, inputProps } = this.props;
+        const { settings, inputProps, ...rest } = this.props;
         return (
             <div>
-                <Input {...inputProps} type="password" onChange={this.onChange} />
+                <Input {...inputProps} type="password" {...rest} onChange={this.onChange} />
                 <PasswordStrengthIndicator
                     level={this.state.level}
                     settings={settings!}


### PR DESCRIPTION
Fixing forwarding of all unused event listeners to child `Input` component. This is necessary for certain use cases when a parent component needs to listen to events from the input field (e.g. onBlur, etc).